### PR TITLE
Option to allow to control the AgentForwarding setting for ssh_config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ script:
   - gem install bundler
   - bundle install --path vendor/bundle
   - bundle exec rake
+before_deploy:
+- rvm $(travis_internal_ruby) --fuzzy do ruby -S gem install puppet -v 5.5.6
 matrix:
   include:
   - rvm: 2.1.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,6 @@
 
 ## [2.6.0] - 2018-07-19
 * initial public release
+
+## [2.7.0] - 2018-10-16
+* added option to allow AgentForwarding for bastion hosts, as example

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # CHANGELOG
 ## [UNRELEASED]
 
-## [2.6.0] - 2018-07-19
-* initial public release
-
 ## [2.7.0] - 2018-10-16
 * added option to allow AgentForwarding for bastion hosts, as example
+
+## [2.6.0] - 2018-07-19
+* initial public release

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,6 +15,7 @@ class secc_sshd (
   $ext_sshd_AuthorizedKeysCommand           = undef,
   $ext_sshd_AuthorizedKeysCommandUser       = 'nobody',
   $ext_sshd_ChallengeResponseAuthentication = 'no',
+  $ext_ssh_ForwardAgent                     = 'no',
   $ext_ssh_KexAlgorithms                    = 'diffie-hellman-group-exchange-sha256',
   $ext_ssh_Ciphers                          = 'aes256-ctr',
   $ext_ssh_MACs                             = 'hmac-sha2-512,hmac-sha2-256',
@@ -38,6 +39,7 @@ class secc_sshd (
   $sshd_AuthorizedKeysCommand           = hiera(sshd_AuthorizedKeysCommand, $ext_sshd_AuthorizedKeysCommand)
   $sshd_AuthorizedKeysCommandUser       = hiera(sshd_AuthorizedKeysCommandUser, $ext_sshd_AuthorizedKeysCommandUser)
   $sshd_ChallengeResponseAuthentication = hiera(sshd_ChallengeResponseAuthentication, $ext_sshd_ChallengeResponseAuthentication)
+  $ssh_ForwardAgent                     = hiera(ssh_ForwardAgent, $ext_ssh_ForwardAgent)
   $ssh_KexAlgorithms                    = hiera(ssh_KexAlgorithm, $ext_ssh_KexAlgorithms)
   $ssh_Ciphers                          = hiera(ssh_Ciphers, $ext_ssh_Ciphers)
   $ssh_MACs                             = hiera(ssh_MACs, $ext_ssh_MACs)
@@ -65,6 +67,7 @@ class secc_sshd (
   include secc_sshd::service
 
   class { 'secc_sshd::ssh_config':
+    ssh_ForwardAgent  => $ssh_ForwardAgent,
     ssh_KexAlgorithms => $ssh_KexAlgorithms,
     ssh_Ciphers       => $ssh_Ciphers,
     ssh_MACs          => $ssh_MACs,

--- a/manifests/ssh_config.pp
+++ b/manifests/ssh_config.pp
@@ -2,6 +2,7 @@
 class secc_sshd::ssh_config (
   $ssh_KexAlgorithms,
   $ssh_Ciphers,
+  $ssh_ForwardAgent,
   $ssh_MACs
 ) {
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "tsystemsmms-secc_sshd",
   "author": "T-Systems Multimedia Solutions GmbH",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "summary": "Dieses Modul bietet eine teilweise Abdeckung der SoC Anforderungen für SSH unter Linux.",
   "license": "Apache-2.0",
   "project_page": "https://github.com/T-Systems-MMS/puppet-secc_sshd",

--- a/spec/acceptance/secc_sshd_custom_settings_spec.rb
+++ b/spec/acceptance/secc_sshd_custom_settings_spec.rb
@@ -14,6 +14,7 @@ describe 'Class secc_sshd' do
         ext_sshd_DenyUsers                        => 'test_deny',
         ext_sshd_DenyGroups                       => 'test_deny',
         ext_sshd_ChallengeResponseAuthentication  => 'yes',
+        ext_ssh_ForwardAgent                      => 'yes'
       }
     EOS
     }
@@ -47,6 +48,7 @@ describe 'Class secc_sshd' do
       its(:content) { is_expected.to include 'DenyUsers test_deny' }
       its(:content) { is_expected.to include 'DenyGroups test_deny' }
       its(:content) { is_expected.to include 'ChallengeResponseAuthentication yes' }
+      its(:content) { is_expected.to include 'ForwardAgent yes' }
     end
   end
 end

--- a/spec/acceptance/secc_sshd_custom_settings_spec.rb
+++ b/spec/acceptance/secc_sshd_custom_settings_spec.rb
@@ -48,6 +48,13 @@ describe 'Class secc_sshd' do
       its(:content) { is_expected.to include 'DenyUsers test_deny' }
       its(:content) { is_expected.to include 'DenyGroups test_deny' }
       its(:content) { is_expected.to include 'ChallengeResponseAuthentication yes' }
+    end
+
+    describe file('/etc/ssh/ssh_config') do
+      it { is_expected.to be_file }
+      it { is_expected.to be_owned_by 'root' }
+      it { is_expected.to be_grouped_into 'root' }
+      it { is_expected.to be_mode 644 }
       its(:content) { is_expected.to include 'ForwardAgent yes' }
     end
   end

--- a/templates/ssh_config.erb
+++ b/templates/ssh_config.erb
@@ -26,7 +26,7 @@ VerifyHostKeyDNS ask
 #	Wird nicht auf den Zielsystemen umgesetzt, sondern auf Sprungservern.
 ############################
 Host *
-ForwardAgent no
+ForwardAgent <%= @ssh_ForwardAgent %>
 ForwardX11 no
 ForwardX11Trusted no
 


### PR DESCRIPTION
Hi,

to ensure our private keys by not spreading that keys to multiple jumphosts, we need that option.
I've adjusted what needs to be done.

fingers crossed for the tests :)


Thanks,
Robert