### PR TITLE
remove deprecated protocol v1 options from sshd config, fixing #10

### DIFF
--- a/spec/acceptance/secc_sshd_spec.rb
+++ b/spec/acceptance/secc_sshd_spec.rb
@@ -50,13 +50,11 @@ describe 'Class secc_sshd' do
       its(:content) { is_expected.to include 'SyslogFacility AUTHPRIV' }
       its(:content) { is_expected.to include 'LogLevel VERBOSE' }
       its(:content) { is_expected.to include 'PasswordAuthentication no' }
-      its(:content) { is_expected.to include 'RSAAuthentication yes' }
       its(:content) { is_expected.to include 'ChallengeResponseAuthentication no' }
       its(:content) { is_expected.to include 'PermitEmptyPasswords no' }
       its(:content) { is_expected.to include 'PubKeyAuthentication yes' }
       its(:content) { is_expected.to include 'PermitRootLogin without-password' }
       its(:content) { is_expected.to include 'AuthorizedKeysFile .ssh/authorized_keys' }
-      its(:content) { is_expected.to include 'RhostsRSAAuthentication no' }
       its(:content) { is_expected.to include 'HostbasedAuthentication no' }
       its(:content) { is_expected.to include 'IgnoreRhosts yes' }
       its(:content) { is_expected.to include 'StrictModes yes' }
@@ -72,8 +70,6 @@ describe 'Class secc_sshd' do
       its(:content) { is_expected.to include 'AcceptEnv XMODIFIERS' }
       its(:content) { is_expected.to include 'Subsystem       sftp    /usr/libexec/openssh/sftp-server' }
       its(:content) { is_expected.to include 'HostKey /etc/ssh/ssh_host_rsa_key' }
-      its(:content) { is_expected.to include 'KeyRegenerationInterval 1h' }
-      its(:content) { is_expected.to include 'ServerKeyBits 2048' }
       its(:content) { is_expected.to include 'LoginGraceTime 2m' }
       its(:content) { is_expected.to include 'TCPKeepAlive yes' }
       its(:content) { is_expected.to include 'Compression delayed' }

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -115,7 +115,6 @@ LogLevel VERBOSE
 ChallengeResponseAuthentication <%= @sshd_ChallengeResponseAuthentication %>
 <% end -%>
 PasswordAuthentication no
-RSAAuthentication yes
 PermitEmptyPasswords no
 PubKeyAuthentication yes
 PermitRootLogin without-password
@@ -128,7 +127,6 @@ AuthorizedKeysCommandUser <%= @sshd_AuthorizedKeysCommandUser %>
 <% end -%>
 <% end -%>
 
-RhostsRSAAuthentication no
 HostbasedAuthentication no
 IgnoreRhosts yes
 
@@ -164,8 +162,6 @@ AcceptEnv XMODIFIERS
 <%# now RedHat or CentOS %><% if @operatingsystem != "SLES" -%>Subsystem       sftp    /usr/libexec/openssh/sftp-server<% end -%>
 
 HostKey /etc/ssh/ssh_host_rsa_key
-KeyRegenerationInterval 1h
-ServerKeyBits 2048
 
 LoginGraceTime 2m
 


### PR DESCRIPTION
its save to remove the options, sice they are for SSH-1 and we have a hardcoded config allowing only SSH-2