### PR TITLE
Updating SOC requirements for #16

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,7 +6,7 @@ class secc_sshd (
   $ext_sshd_AllowGroups                     = '',
   $ext_sshd_DenyUsers                       = '',
   $ext_sshd_DenyGroups                      = '',
-  $ext_sshd_KexAlgorithms                   = 'diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha1',
+  $ext_sshd_KexAlgorithms                   = 'diffie-hellman-group-exchange-sha256',
   $ext_sshd_AllowTcpForwarding              = 'no',
   $ext_sshd_AllowAgentForwarding            = 'no',
   $ext_sshd_Ciphers                         = 'aes256-ctr',

--- a/spec/acceptance/secc_sshd_spec.rb
+++ b/spec/acceptance/secc_sshd_spec.rb
@@ -40,7 +40,7 @@ describe 'Class secc_sshd' do
       its(:content) { is_expected.to include 'Protocol 2' }
       its(:content) { is_expected.to include 'Ciphers aes256-ctr' }
       its(:content) { is_expected.to include 'MACs hmac-sha2-512,hmac-sha2-256' }
-      its(:content) { is_expected.to include 'KexAlgorithms diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha1' }
+      its(:content) { is_expected.to include 'KexAlgorithms diffie-hellman-group-exchange-sha256' }
       its(:content) { is_expected.to include 'AllowTcpForwarding no' }
       its(:content) { is_expected.to include 'GatewayPorts no' }
       its(:content) { is_expected.to include 'X11Forwarding no' }
@@ -75,7 +75,7 @@ describe 'Class secc_sshd' do
       its(:content) { is_expected.to include 'AcceptEnv XMODIFIERS' }
       its(:content) { is_expected.to include 'Subsystem       sftp    /usr/libexec/openssh/sftp-server' }
       its(:content) { is_expected.to include 'HostKey /etc/ssh/ssh_host_rsa_key' }
-      its(:content) { is_expected.to include 'LoginGraceTime 2m' }
+      its(:content) { is_expected.to include 'LoginGraceTime 1m' }
       its(:content) { is_expected.to include 'TCPKeepAlive yes' }
       its(:content) { is_expected.to include 'Compression delayed' }
       its(:content) { is_expected.to include 'ClientAliveInterval 120' }

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -163,7 +163,8 @@ AcceptEnv XMODIFIERS
 
 HostKey /etc/ssh/ssh_host_rsa_key
 
-LoginGraceTime 2m
+LoginGraceTime 1m
+MaxAuthTries 5
 
 TCPKeepAlive yes
 # Added a new compression method that delays the start of zlib compression until the user has been authenticated successfully. The new method ("Compression delayed") is on by default in the server.


### PR DESCRIPTION
Updates in this PR:

**SoC List Secure Shell, latest Version**

Anforderung 3: Nur freigegebene Algorithmen zum Schlüsselaustausch dürfen verwendet werden. - **removed diffie-hellman-group14-sha1**

$ext_sshd_KexAlgorithms = 'diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha1',
Anforderung 7 SSH LoginGraceTime muss auf eine Minute oder niedriger konfiguriert werden. - **set LoginGraceTime to
1m** (current value 2min/120s)

Anforderung 8 SSH MaxAuthTries muss auf 5 oder niedriger gesetzt werden. - **set MaxAuthTries to 5** (current Value 6)